### PR TITLE
fix: surface rclone stderr on failure

### DIFF
--- a/download_wdi.py
+++ b/download_wdi.py
@@ -19,12 +19,16 @@ R2_BUCKET_WDI = "r2:wdi"
 
 def download_file(url, dest_dir):
     print(f"Downloading WDI data from {url} using rclone...")
-    result = subprocess.run(
-        ["rclone", "copyurl", url, dest_dir, "--auto-filename", "--print-filename"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
+    try:
+        result = subprocess.run(
+            ["rclone", "copyurl", url, dest_dir, "--auto-filename", "--print-filename"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"rclone error:\n{e.stderr}")
+        raise
     filename = result.stdout.strip()
     print(f"Downloaded file: {filename}")
     return os.path.join(dest_dir, filename)


### PR DESCRIPTION
Improved error visibility for `rclone` command failures in `download_wdi.py`. When `subprocess.run` fails, it now outputs the captured `stderr` before raising the `CalledProcessError`.

---
*PR created automatically by Jules for task [17674401163750001814](https://jules.google.com/task/17674401163750001814) started by @nickbrett1*