### PR TITLE
Group coupled dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      dbt-core-sqlparse:
+        patterns:
+          - "dbt-core"
+          - "sqlparse"
+      pydantic:
+        patterns:
+          - "pydantic"
+          - "pydantic-core"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot would frequently raise pull requests for `dbt-core` or `sqlparse` (and similarly `pydantic` and `pydantic-core`) individually. Since `dbt-core` restricts its allowable `sqlparse` versions and vice versa, upgrading only one part results in strict circular dependency conflicts, breaking pip installations and CI checks.

By specifying grouping rules for these tightly-coupled packages in `.github/dependabot.yml`, Dependabot will now combine their updates into single, atomic Pull Requests that upgrade both the root dependency and its critical transitive dependency at the same time, maintaining valid `requirements.txt` constraints.

---
*PR created automatically by Jules for task [14804727445855692596](https://jules.google.com/task/14804727445855692596) started by @nickbrett1*