### PR TITLE
fix: update dbt docs generation to use compile --write-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,13 +103,12 @@ jobs:
           name: Generate dbt docs
           command: |
             pushd wdi
-            dbt docs generate --target prod
+            dbt compile --target prod --write-catalog
             popd
       # Upload the generated static_index.html to R2 docs folder
       - run:
           name: Upload dbt docs static index to R2
           command: |
-            rclone copy wdi/target/index.html r2:wdi/docs --checksum
             rclone copy wdi/target/manifest.json r2:wdi/docs --checksum
             rclone copy wdi/target/catalog.json r2:wdi/docs --checksum
       # Install sqlite3 so that the sqlite3 command is available for export


### PR DESCRIPTION
The `dbt docs generate` command is deprecated in dbt-core 2.0.0 and fails when used with the `--static` argument or when run without it. The newer standard approach is to use `dbt compile --write-catalog` to write `catalog.json` and `manifest.json`.
This removes the `dbt docs generate` command and the subsequent attempt to copy `wdi/target/index.html` to R2, replacing them with `dbt compile --write-catalog`.

---
*PR created automatically by Jules for task [960732853769771551](https://jules.google.com/task/960732853769771551) started by @nickbrett1*